### PR TITLE
Add support for mac os

### DIFF
--- a/macos_src_bin/ADD_REG_1.asm
+++ b/macos_src_bin/ADD_REG_1.asm
@@ -1,0 +1,59 @@
+global _ADD_REG_1
+
+section .text
+
+%macro ADD_MACRO 0
+	add rax, 1
+	add rdx, 1
+	add rdi, 1
+	add rsi, 1
+	add r11, 1
+	add r8, 1
+	add r9, 1
+	add r10, 1
+%endmacro
+
+_ADD_REG_1:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+	push rdx
+
+	mov rcx, (1024*1024*1024)/128
+
+.LoopHead:
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+	ADD_MACRO
+
+	dec rcx
+	jnz .LoopHead
+
+	pop rdx
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret

--- a/macos_src_bin/AND_REG_REG.asm
+++ b/macos_src_bin/AND_REG_REG.asm
@@ -1,0 +1,61 @@
+global _AND_REG_REG
+
+section .text
+
+%macro AND_MACRO 0
+	and rax, r12
+	and rdx, r12
+	and rdi, r12
+	and rsi, r12
+	and r11, r12
+	and r8, r12
+	and r9, r12
+	and r10, r12
+%endmacro
+
+
+
+_AND_REG_REG:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+	push r12
+
+	mov rcx, (1024*1024*1024)/128
+
+.LoopHead:
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+	AND_MACRO
+
+	dec rcx
+	jnz .LoopHead
+
+	pop r12
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret

--- a/macos_src_bin/AVXChecker.asm
+++ b/macos_src_bin/AVXChecker.asm
@@ -1,0 +1,34 @@
+global _GetAVXCapability
+global _GetSSECapability
+
+section .text
+
+; Checks CPUID for AVX capability
+_GetAVXCapability:
+	push rbx
+	
+	mov eax, 1
+	cpuid
+
+	mov eax, ecx
+	shr eax, 28		; Read bit 28
+	and eax, 1
+
+	pop rbx
+	ret
+
+
+; Checks CPUID for SSE capability
+_GetSSECapability:
+	push rbx
+	
+	mov eax, 1
+	cpuid
+
+	mov eax, edx
+	shr eax, 25		; Read bit 25
+	and eax, 1
+
+	pop rbx
+	ret
+

--- a/macos_src_bin/CMOVcc_REG_REG.asm
+++ b/macos_src_bin/CMOVcc_REG_REG.asm
@@ -1,0 +1,58 @@
+global _CMOVcc_REG_REG
+
+section .text
+
+%macro CMOV_MACRO 0
+	cmove rdx, rax
+	cmove rbx, rax
+	cmove rsi, rax
+	cmove rdi, rax
+	cmove r8, rax
+	cmove r9, rax
+	cmove r10, rax
+	cmove r11, rax
+%endmacro
+
+_CMOVcc_REG_REG:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+
+	mov rcx, (1024*1024*1024)/128
+
+.LoopHead:
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	CMOV_MACRO
+	
+	dec rcx
+	jnz .LoopHead
+
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+
+	ret

--- a/macos_src_bin/FLOPS.asm
+++ b/macos_src_bin/FLOPS.asm
@@ -1,0 +1,130 @@
+global _FLOPS_SSE
+global _FLOPS_AVX
+
+section .text
+
+; 8x phenom II
+%macro ADD_SSE 0
+	addps xmm1, xmm0
+	addps xmm2, xmm0
+	addps xmm3, xmm0
+	addps xmm4, xmm0
+	addps xmm5, xmm0
+	addps xmm6, xmm0
+	addps xmm7, xmm0
+	addps xmm8, xmm0
+%endmacro
+
+; For AVX capable CPU's
+%macro ADD_AVX 0
+	vaddps ymm1, ymm1, ymm0
+	vaddps ymm2, ymm2, ymm0
+	vaddps ymm3, ymm3, ymm0
+	vaddps ymm4, ymm4, ymm0
+	vaddps ymm5, ymm5, ymm0
+	vaddps ymm6, ymm6, ymm0
+	vaddps ymm7, ymm7, ymm0
+	vaddps ymm8, ymm8, ymm0
+%endmacro
+
+_FLOPS_SSE:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+
+	push r12
+
+	mov r12, (1024*1024*1024)/(128 * 4)	; x4 for SSE
+
+.LoopHead:
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+	ADD_SSE
+
+	dec r12
+	jnz .LoopHead
+
+	pop r12
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret
+
+_FLOPS_AVX:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+	push r12
+
+	mov r12, (1024*1024*1024)/(128 * 8)		; x8 for AVX
+
+	; Set all the AVX regs to 0.0
+	vxorps ymm0, ymm0, ymm0
+	vxorps ymm1, ymm1, ymm1
+	vxorps ymm2, ymm2, ymm2
+	vxorps ymm3, ymm3, ymm3
+	vxorps ymm4, ymm4, ymm4
+	vxorps ymm5, ymm5, ymm5
+	vxorps ymm6, ymm6, ymm6
+	vxorps ymm7, ymm7, ymm7
+	vxorps ymm8, ymm8, ymm8
+
+.LoopHead:
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+	ADD_AVX
+
+	dec r12
+	jnz .LoopHead
+
+	pop r12
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret

--- a/macos_src_bin/IMUL_REG_REG.asm
+++ b/macos_src_bin/IMUL_REG_REG.asm
@@ -1,0 +1,69 @@
+global _IMUL_REG_REG
+
+section .text
+
+%macro IMUL_MACRO 0
+	imul rax, rbx
+	imul rdx, rbx
+	imul rdi, rbx
+	imul rsi, rbx
+	imul r11, rbx
+	imul r8, rbx
+	imul r9, rbx
+	imul r10, rbx
+%endmacro
+
+_IMUL_REG_REG:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+
+	mov rcx, (1024*1024*1024)/128
+
+	; Set all the accumulators to 1
+	mov rbx, 1
+	mov rax, 1
+	mov rdx, 1
+	mov rdi, 1
+	mov rsi, 1
+	mov r11, 1
+	mov r8, 1
+	mov r9, 1
+	mov r10, 1
+
+.LoopHead:
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+	IMUL_MACRO
+
+	dec rcx
+	jnz .LoopHead
+
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret
+

--- a/macos_src_bin/PADDB_MMX.asm
+++ b/macos_src_bin/PADDB_MMX.asm
@@ -1,0 +1,55 @@
+global _PADDB_MMX
+
+section .text
+
+%macro PADD_MACRO 0
+	paddb mm1, mm0
+	paddb mm2, mm0
+	paddb mm3, mm0
+	paddb mm4, mm0
+%endmacro
+
+_PADDB_MMX:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+
+	mov rcx, (1024*1024*1024)/(32 * 8)	; 8 for 8 bytes in MMX
+
+.LoopHead:
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+	PADD_MACRO
+
+	dec rcx
+	jnz .LoopHead
+
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+
+	emms		; Exit multimedia state, return to x87
+	ret

--- a/macos_src_bin/SHR_REG_CL.asm
+++ b/macos_src_bin/SHR_REG_CL.asm
@@ -1,0 +1,60 @@
+global _SHR_REG_CL
+
+section .text
+
+%macro SHR_MACRO 0
+	shr rax, cl
+	shr rdx, cl
+	shr rdi, cl
+	shr rsi, cl
+	shr r11, cl
+	shr r8, cl
+	shr r9, cl
+	shr r10, cl
+%endmacro
+
+_SHR_REG_CL:
+	push rbx
+	push rdi
+	push rsi
+	push rbp
+	push r11
+	push r8
+	push r9
+	push r10
+
+	push r12
+
+	mov r12, (1024*1024*1024)/128
+
+.LoopHead:
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	SHR_MACRO
+	
+	dec r12
+	jnz .LoopHead
+
+	pop r12
+	pop r10
+	pop r9
+	pop r8
+	pop r11
+	pop rbp
+	pop rsi
+	pop rdi
+	pop rbx
+	ret

--- a/macos_src_bin/asm.asm
+++ b/macos_src_bin/asm.asm
@@ -1,0 +1,8 @@
+%include "AND_REG_REG.asm"
+%include "CMOVcc_REG_REG.asm"
+%include "PADDB_MMX.asm"
+%include "ADD_REG_1.asm"
+%include "SHR_REG_CL.asm"
+%include "AVXChecker.asm"
+%include "FLOPS.asm"
+%include "IMUL_REG_REG.asm"

--- a/macos_src_bin/main.cpp
+++ b/macos_src_bin/main.cpp
@@ -1,0 +1,221 @@
+#include <iostream>
+#include <ctime>
+#include <thread>
+#include <mutex>
+#include <vector>
+
+// Checker function for AVX and SSE
+extern "C" bool GetAVXCapability();
+extern "C" bool GetSSECapability();
+
+// Job functions  (Note: ThreadID is included for future versions)
+// Each executes 1024^3 times, 1 gig, or around 1 billion operations.
+extern "C" void ADD_REG_1(int threadID);
+extern "C" void AND_REG_REG(int threadID);
+extern "C" void SHR_REG_CL(int threadID);
+extern "C" void PADDB_MMX(int threadID);
+extern "C" void CMOVcc_REG_REG(int threadID);
+extern "C" void FLOPS_SSE(int threadID);
+extern "C" void FLOPS_AVX(int threadID);
+
+// MUL added for Reirei
+extern "C" void IMUL_REG_REG(int threadID);
+
+// Lock for the jobs vector
+std::mutex workMutex;
+
+// Jobs vector
+std::vector< void(*)(int) > work;
+
+void Execute(int threadID)
+{
+	// The following is not necessary nor cross-platform
+	//SetThreadPriority(GetCurrentThread(), 2);
+	//SetThreadAffinityMask(GetCurrentThread(), 1 << threadID);
+
+	// Whilte there's jobs to be done
+	while (true)
+	{
+		// Thread's job (if it has one, NULL if it doesn't)
+		void (*func)(int);
+
+		// Lock mutex
+		workMutex.lock();
+
+		// Assume there's no more work
+		func = NULL;
+
+		// If there's more work, grab a job
+		if (work.size() != 0)
+		{
+			func = work.back();
+			work.pop_back();
+		}
+		// Unlock mutex
+		workMutex.unlock();
+
+		// If there's a job, execute it
+		if (func != NULL)
+			func(threadID);
+		// Otherwise, return
+		else
+			return;
+	}
+}
+
+int main()
+{
+	double phenom2_performance[] = {
+		// Multithreaded
+		30.099969,			// Add
+		30.564951,			// Bool
+		30.106989,			// Shift CL
+		82.588283,			// MMX
+		30.091751,			// CMOVcc
+		41.371507,			// Flops
+		1.0,				// IMUL
+		// Single threaded
+		7.5403567,			// Add
+		7.6557838,			// Bool
+		7.5400756,			// Shift CL
+		20.704509,			// MMX
+		7.5366694,			// CMOVcc
+		10.36873,			// Flops
+		1.0					// IMUL
+	};
+
+	// Check for AVX capability
+	bool AVX_CAPABLE = GetAVXCapability();
+	bool SSE_CAPABLE = GetSSECapability();
+
+	// Limit output digits to 4
+	std::cout.precision(4);
+
+	const int RUNS = 10;			// Repeitions, so we can find a fast time
+	const int MAX_THREADS = 64;		// Maximum number of threads
+	const int JOB_COUNT = 100;		// Jobs to perform (threads keep checking until all jobs are done)
+	int threadCount = std::thread::hardware_concurrency();			// Actual thread count of this CPU
+	std::thread* t[MAX_THREADS];	// 16 is the maximum number of threads
+	int option = -1;				// Option variable for use input
+	double fastest = 0.0;			// Record of the fastest time recorded
+	void(*currentFunction)(int);	// Pointer to the currently selected function
+
+	// Output some info
+	std::cout<<"* * *  Welcome to How Many Phenom II's is My CPU!  * * *"<< std::endl;
+	std::cout<< std::endl;
+	std::cout<<"This benchmark will time your CPU performance against an"<< std::endl;
+	std::cout<<"AMD Quad Core Phenom II 810 from the year 2009."<< std::endl;
+	std::cout<<std::endl;
+
+	if (AVX_CAPABLE)
+		std::cout<<"AVX CPU detected!"<< std::endl;
+	else
+		std::cout<<"No AVX support detected" << std::endl;
+	if (SSE_CAPABLE)
+		std::cout<<"SSE CPU detected!" << std::endl;
+	else
+		std::cout<<"SSE capable CPU is required FLOPS test."<<std::endl;
+
+	std::cout<<"Threads available: "<< threadCount << " vs. 4 for Phenom II" << std::endl;
+
+	while (option != 0)
+	{
+		// Reset option
+		option = -1;
+
+		// Reset fastest:
+		fastest = 0.0;
+
+		while (option == -1)
+		{
+			std::cout<<std::endl;
+			std::cout<<"Select a benchmark (or 0 to quit): "<< std::endl;
+			std::cout<<"1. ADD REG, 1		(GPR arithmetic)" << std::endl;
+			std::cout<<"2. AND REG, REG		(GPR Boolean)" << std::endl;
+			std::cout<<"3. SHR REG, CL		(Variable shifts - Phenom's phorte)" << std::endl;
+			std::cout<<"4. PADDB MMX		(Obsolete instruction set)"<< std::endl;
+			std::cout<<"5. CMOVcc REG, REG	(Branchless programming)" << std::endl;
+			std::cout<<"6. FLOPS		(Floating point with best set)" << std::endl;
+			std::cout<<"7. IMUL REG, REG	(GPR Multiplication)"<< std::endl;
+			std::cout<<"8. Toggle Multi vs. Single Threads (Current="<<threadCount<<")"<<std::endl;
+			std::cout<<"0. Quit" << std::endl;
+
+			std::cin>>option;
+	
+			// Reset to -1 if the input is invalid
+			option = (option * (option >= 0 && option <= 8))
+				+ (-1 * !(option >= 0 && option <= 8));
+		}
+
+		switch (option)
+		{
+		case 0: break;
+		case 1: currentFunction = ADD_REG_1; break;
+		case 2: currentFunction = AND_REG_REG; break;
+		case 3: currentFunction = SHR_REG_CL; break;
+		case 4: currentFunction = PADDB_MMX; break;
+		case 5: currentFunction = CMOVcc_REG_REG; break;
+		case 6: currentFunction = (void (*)(int))				// Select SSE or AVX
+			((unsigned long long)FLOPS_SSE * !AVX_CAPABLE +
+			(unsigned long long)FLOPS_AVX * AVX_CAPABLE); break;
+		case 7: currentFunction = IMUL_REG_REG; break;
+		case 8: threadCount = (1 * (threadCount != 1)) +		// Toggle threaded or single thread
+			(std::thread::hardware_concurrency() * (threadCount == 1)); break;
+		}
+
+		if (option == 0)	// Allow quit
+			break;
+		if (option == 8)	// Continue if the thread count has been changed
+			continue;
+
+		// Loop RUNS times through the benchmark
+		for (int r = 0; r < RUNS; r++)
+		{
+			// Add jobs to the Jobs vector
+			for (int i = 0; i < JOB_COUNT; i++)
+				work.push_back(currentFunction);
+
+			// Start the clock
+			long startTime = clock();
+
+			// Start the threads
+			for (int i = 0; i < threadCount; i++)
+				t[i] = new std::thread(Execute, i);
+
+			// Wait for them to finish
+			for (int i = 0; i < threadCount; i++)
+				t[i]->join();
+
+			// Stop the clock
+			long finishTime = clock();
+
+			// Compute the time taken for this run
+			double thisTime = (double)(finishTime - startTime) / CLOCKS_PER_SEC;
+			thisTime /= (double)threadCount;	// ctime's clock seems to sum times of each thread
+
+			// Update fastest if this time beat it
+			if (thisTime < fastest || fastest == 0.0)
+				fastest = thisTime;
+
+			// Output time for this run
+			std::cout<<"Run "<< (r+1) << "/" << RUNS <<" Time: "<< thisTime << std::endl;
+
+			// Delete the threads
+			for (int i = 0; i < threadCount; i++)
+				delete t[i];
+		}
+
+		double gops = ((((1024*1024*1024)/1000000000.0)
+			/ fastest) * (double)JOB_COUNT);
+
+		double phenom2 = phenom2_performance[(option-1)
+		 + (7 * (threadCount == 1))];
+
+		std::cout<<"Executed "<< gops << " billion instructions/second" <<std::endl;
+		std::cout<<	"Score: "<< (gops / phenom2) << " Phenom's II's worth's" << std::endl;
+	}
+
+	std::cout<<"See ya... "<< std::endl;
+
+	return 0;
+}

--- a/macos_src_bin/makefile
+++ b/macos_src_bin/makefile
@@ -1,0 +1,5 @@
+phenom2_benchmark: main.cpp asm.o
+	g++ -std=c++11 main.cpp asm.o -lpthread -ffast-math -msse3 -O3 -o phenom2_benchmark
+
+asm.o: asm.asm AND_REG_REG.asm CMOVcc_REG_REG.asm PADDB_MMX.asm ADD_REG_1.asm SHR_REG_CL.asm AVXChecker.asm FLOPS.asm IMUL_REG_REG.asm
+	nasm asm.asm -fmacho64 -o asm.o


### PR DESCRIPTION
Thanks for this interesting benchmark!

I found some issues when trying to run it on mac os, more specifically:
- Need to prepend underscore to global asm functions.
- One issue with thread constructors. I fixed it adding `-std=c++11` to g++
- Change in architecture parameter to nasm